### PR TITLE
Improve email verification page styling

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const port = process.env.PORT || 3000;
 // Middleware para parsear JSON. 
 app.use(bodyParser.json());
 app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
 const upload = multer({ storage: multer.memoryStorage() });
 
 // Configuración de transporte para enviar correos.
@@ -395,7 +396,7 @@ app.get('/api/verify-email', (req, res) => {
           console.error('Error al verificar el usuario:', updErr);
           return res.status(500).send('Error al verificar el usuario');
         }
-        res.send('Cuenta verificada con éxito');
+        res.sendFile(path.join(__dirname, 'public', 'verify-success.html'));
       });
     });
   });

--- a/public/verify-success.html
+++ b/public/verify-success.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Cuenta verificada</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      display: flex;
+      height: 100vh;
+      background: #f9fafb;
+      color: #111827;
+      align-items: center;
+      justify-content: center;
+      font-family: "Inter", sans-serif;
+    }
+    .container {
+      text-align: center;
+      padding: 40px;
+      border-radius: 8px;
+      background: #ffffff;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+    }
+    h1 {
+      font-weight: 500;
+      margin: 0 0 8px;
+    }
+    p {
+      color: #6b7280;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>¡Cuenta verificada!</h1>
+    <p>Ya puedes cerrar esta ventana.</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve static files from a new `public` folder
- create a styled `verify-success.html` page
- show the verification page after successful email verification

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685322c74f10832b84aa0b1befdeb049