### PR TITLE
Fix missing gOPD module

### DIFF
--- a/node_modules/gopd/gOPD.js
+++ b/node_modules/gopd/gOPD.js
@@ -1,0 +1,4 @@
+'use strict';
+
+/** @type {import('./gOPD')} */
+module.exports = Object.getOwnPropertyDescriptor;


### PR DESCRIPTION
## Summary
- add the `gOPD.js` file that `gopd` expects

## Testing
- `npm start` *(fails: Neither apiKey nor config.authenticator provided)*

------
https://chatgpt.com/codex/tasks/task_e_687a75a78b9c832ba736374bc0238ee3