### PR TITLE
Exclude Stripe webhooks from JWT auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,11 @@ transporter.verify().catch(err => {
 
 // Middleware para verificar tokens JWT
 function authenticateToken(req, res, next) {
+  // Los webhooks de Stripe no envían JWT, por lo que deben quedar excluidos
+  if (req.path.startsWith('/webhooks/stripe')) {
+    return next();
+  }
+
   const authHeader = req.headers['authorization'];
   const token = authHeader && authHeader.split(' ')[1];
 


### PR DESCRIPTION
## Summary
- Skip JWT authentication for `/webhooks/stripe` so Stripe can call the endpoint without a token

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c7bf24f8832b9e026540e179c29e