### PR TITLE
Return 401 for expired JWT tokens

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,6 +105,9 @@ function authenticateToken(req, res, next) {
 
   jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
     if (err) {
+      if (err.name === 'TokenExpiredError') {
+        return res.status(401).json({ error: 'Token expirado' });
+      }
       return res.status(403).json({ error: 'Token inválido' });
     }
     req.user = user;


### PR DESCRIPTION
## Summary
- return a 401 Unauthorized response when JWT verification fails due to expiration
- keep 403 Forbidden responses for other invalid token scenarios so clients can distinguish cases

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d567f77598832b9b124bfa65a72c19